### PR TITLE
Added Serializable interface to the BreadCrumbLink class.

### DIFF
--- a/src/main/java/dummiesmind/breadcrumb/springmvc/breadcrumb/BreadCrumbLink.java
+++ b/src/main/java/dummiesmind/breadcrumb/springmvc/breadcrumb/BreadCrumbLink.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class BreadCrumbLink implements Serializable {
 
-  private static final long serialVersionUID = -1734182996388561350L;
+	private static final long serialVersionUID = -1734182996388561350L;
 
 	private BreadCrumbLink previous;
 	private List<BreadCrumbLink> next = new LinkedList<BreadCrumbLink>();

--- a/src/main/java/dummiesmind/breadcrumb/springmvc/breadcrumb/BreadCrumbLink.java
+++ b/src/main/java/dummiesmind/breadcrumb/springmvc/breadcrumb/BreadCrumbLink.java
@@ -1,9 +1,12 @@
 package dummiesmind.breadcrumb.springmvc.breadcrumb;
 
+import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
 
-public class BreadCrumbLink {
+public class BreadCrumbLink implements Serializable {
+
+  private static final long serialVersionUID = -1734182996388561350L;
 
 	private BreadCrumbLink previous;
 	private List<BreadCrumbLink> next = new LinkedList<BreadCrumbLink>();


### PR DESCRIPTION
I offer to add Serializable interface to BreadCrumbLink to fix an issue with Apache Tomcat: 
"org.apache.catalina.session.StandardSession.doWriteObject 
Cannot serialize session attribute currentBreadCrumb for session [...]
 java.io.NotSerializableException: dummiesmind.breadcrumb.springmvc.breadcrumb.BreadCrumbLink"
